### PR TITLE
Remove unecessary packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,20 +7,18 @@
     "test": "node index.js"
   },
   "dependencies": {
+    "@discordjs/opus": "^0.5.0",
+    "canvas": "2.6.1",
+    "dblapi.js": "2.4.0",
     "discord.js": "12.4.1",
+    "dotenv": "8.2.0",
+    "express": "4.16.2",
+    "ffmpeg-static": "^4.3.0",
+    "google-search-results-nodejs": "^2.0.1",
     "ms": "^2.1.2",
+    "mysql": "2.18.1",
     "request": "2.88.2",
     "util": "^0.12.3",
-    "mysql": "2.18.1",
-    "canvas": "2.6.1",
-    "dotenv": "8.2.0",
-    "ytdl-core": "2.1.7",
-    "@discordjs/opus": "^0.3.2",
-    "ffmpeg": "^0.0.4",
-    "fluent-ffmpeg": "^2.1.2",
-    "erela.js": "^1.1.8",
-    "google-search-results-nodejs": "1.3.0",
-    "dblapi.js": "2.4.0",
-    "express": "4.16.2"
+    "ytdl-core": "^4.5.0"
   }
 }


### PR DESCRIPTION
Because you are going to use ffmpeg as the music handler, there's no need to install erela.js
Secondly, use ffmpeg-static because it is more efficient than the ffmpeg and ffmpeg-fluent